### PR TITLE
adding v2 api to spark onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,187 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage*.xml
+*,cover
+.hypothesis/
+.pytest_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+# *.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+/webserver_config.py
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+docs/rtd-deprecation/_build/
+docs/_doctrees/
+docs/_inventory_cache/
+docs/*/_api/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# nvm (Node Version Manager)
+.nvmrc
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+.autoenv*.zsh
+
+# virtualenv
+.venv*
+venv*
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# PyCharm
+.idea/
+*.iml
+
+# Visual Studio Code
+.vscode/
+
+# vim
+*.swp
+
+# Emacs
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# OSX
 .DS_Store
+
+# SQL Server backups
+*.bkp
+
+# Spark
+rat-results.txt
+
+# Git stuff
+# Kubernetes generated templated files
+*.generated
+*.tar.gz
+scripts/ci/kubernetes/docker/requirements.txt
+
+# Node & Webpack Stuff
+*.entry.js
+node_modules
+npm-debug.log*
+derby.log
+metastore_db
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Needed for CI Dockerfile.ci build system
+.build
+/tmp
+/files
+
+/hive_scratch_dir/
+/.bash_aliases
+/.bash_history
+/.kube
+/.inputrc
+log.txt*
+
+# Docker context files
+/docker-context-files/*
+!/docker-context-files/.README.md
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Terraform variables
+*.tfvars
+
+# Might be generated when you build wheels
+pip-wheel-metadata
+
+.pypirc
+
+/.docs-venv
+
+# Dev files
+/dev/packages.txt
+/dev/Dockerfile.pmc

--- a/chapter_04/day_15.md
+++ b/chapter_04/day_15.md
@@ -1,10 +1,12 @@
 # Day 15 - Basic Spark Topics :sparkles:
 
 ## Overview:
-Today, you'll dive into advanced topics in Apache Spark to enhance your understanding and capabilities in big data processing. You'll explore advanced RDD operations, lazy evaluation, passing functions to Spark, accumulators, broadcast variables, and working on a per-partition basis. These topics are essential for building high-performance Spark applications and optimizing your data processing workflows.
+Today, you will get to know Spark's history, its capabilities, and the problems it aims to solve.
+You will familiarize yourself with basic spark terminology and features that will help you get started in the Apache Spark ecosystem.
+Familiarizing yourself with these topics is essential for building high-performance Spark applications and optimizing your data processing workflows.
 
 ## Goals:
-- Explore advanced topics in Apache Spark to enhance your understanding and capabilities in big data processing.
+- Explore basic Spark terminology and learn basic concepts.
 - Dive deeper into Spark's core concepts and features.
 
 :warning: **Note:**
@@ -15,58 +17,51 @@ Today, you'll dive into advanced topics in Apache Spark to enhance your understa
 - Utilize Google, YouTube, or any other reliable source to gather comprehensive information that helps you grasp each concept thoroughly. This preparation will equip you for a productive question-and-answer session with your mentor, where you'll be expected to discuss what you've learned.
 - **Before you start**  take a look to the [Final Exercise](final_exercise_04.md) and try to understand what you need to do, so you can focus on the main concepts that you need to learn. don't waste your time on the concepts and details that you don't need to know.
 - If you have any questions and have conflicts if you need to learn some concept or not, you should discuss it with your mentor.
+- Read only chapters and subchapters that are listed here.
 
-## 3. Programming with RDDs
-Read the following chapters from the [Spark Book](https://github.com/hemant-rout/BigData/blob/master/Learning%20Spark%20%20Lightning-Fast%20Big%20Data%20Analysis%20.pdf)
+Read the following chapters from the [Spark Book](https://tinyurl.com/ykb29t4f).
 
-- **Topics Covered:**
-  - RDD Basics page
-  - Creating RDDs 
-  - RDD Operations 
-  - Transformations 
-  - Actions 
-  - Lazy Evaluation 
-  - Passing Functions to Spark
-  - Python, Scala, Java 
+:bulb: The numbering of the chapters matches the numbering of the chapters in the book.
+Focus only on the chapters/subchapters mentioned. 
 
-### 1. Spark Core Concepts
+## I. Gentle overview of Big Data and Spark
+**Topics Covered:**
+- What is Apache Spark?
+- A Gentle Introduction to Spark
+- A Tour of Spark's Toolset.
 
-#### 1. **Advanced RDD Operations:**
-   - Dive deeper into RDD operations and explore advanced techniques for manipulating data with RDDs.
-   - Pay attention to performance optimizations, including the use of `mapPartitions()` and `aggregate()` for efficiency.
+### What is Apache Spark?
+- Apache Spark's philosophy.
+- Context: the Big Data problem.
+- History of Spark.
 
-#### 2. **Lazy Evaluation in Depth:**
-   - Gain an in-depth understanding of Spark's lazy evaluation mechanism and how it impacts application performance and resource management.
-   - Learn to utilize lazy evaluation effectively for improved computation.
+### A Gentle Introduction to Spark
+- Spark's basic architecture.
+- Spark's language APIs.
+- Spark's APIs.
+- Starting Spark.
+- The SparkSession.
+- DataFrames.
+- Transformations.
+- Actions.
+- Spark UI.
+- An end to end example.
 
-#### 3. **Passing Functions to Spark:**
-   - Explore advanced techniques for passing functions to Spark, including custom functions and lambdas.
-   - Pay attention to function serialization and best practices to avoid serialization issues.
-
-### 2. Advanced Spark Programming
-
-- **Topics Covered:**
-  - Accumulators 
-  - Broadcast Variables 
-  - Working on a Per-Partition Basis 
-
-#### Core Concepts
-
-##### 1. **Accumulators:**
-   - Learn advanced uses of accumulators in Spark for distributed counters and aggregations.
-   - Pay attention to thread safety when using accumulators in multi-stage Spark applications.
-
-##### 2. **Broadcast Variables:**
-   - Explore advanced optimizations using broadcast variables to efficiently share read-only data across Spark nodes.
-   - Understand scenarios where broadcast variables can significantly improve performance, especially in joins and lookups.
-
-## **Discussion and Q&A:**
-  - Engage in a discussion with mentors and peers to share insights and experiences related to advanced Spark topics.
-  - Ask questions and seek clarification on any challenging concepts.
-   - Discuss real-world applications and implications of advanced Spark programming in big data processing workflows.
+### A Tour of Spark's Toolset
+- Running production applications.
+- Datasets: Type-Safe structured APIs.
+- Lower level APIs.
+- Spark's ecosystem and packages.
 
 ## **Wrapping Up:** :hourglass_flowing_sand:
+**Congratulations on completing Day 15! You've delved into advanced Spark topics, which are crucial for optimizing and fine-tuning your Spark applications. Keep exploring and applying these concepts to excel in big data processing with Spark.**
+
 Discuss with your mentor about the day's learnings and explore potential project applications. Reflect on the significance of advanced Spark topics and how you can apply these concepts in your big data processing endeavors.
+
+**Discussion and Q&A:** :raising_hand:
+  - Engage in a discussion with mentors and peers to share insights and experiences related to advanced Spark topics.
+  - Ask questions and seek clarification on any challenging concepts.
+  - Discuss real-world applications and implications of advanced Spark programming in big data processing workflows.
 
 ## **Action Items:**
 - Identify areas for deeper exploration.
@@ -98,5 +93,3 @@ Discuss with your mentor about the day's learnings and explore potential project
 - [Part 3: Cost Efficient Executor Configuration for Apache Spark](https://link.medium.com/KFlwhEH0Pub) - A guide to cost-efficient executor configuration for Apache Spark applications.
 - [Spark OOM Error — Closeup](https://link.medium.com/LLX1pap0Pub) - A detailed explanation of Spark's Out of Memory (OOM) error and strategies to address it.
 - [3 Reasons Why Spark’s Lazy Evaluation is Useful](https://link.medium.com/faI3jfc0Pub) - An exploration of the benefits of Spark's lazy evaluation mechanism.
-
-**Congratulations on completing Day 11! You've delved into advanced Spark topics, which are crucial for optimizing and fine-tuning your Spark applications. Keep exploring and applying these concepts to excel in big data processing with Spark.**

--- a/chapter_04/day_16.md
+++ b/chapter_04/day_16.md
@@ -1,80 +1,123 @@
 # Day 16 - Advanced Spark Topics :fire:
 
 ## Overview:
-Today's focus is on advancing your expertise in Apache Spark with an emphasis on understanding cluster operations and optimizing Spark applications for better performance. You'll delve into Spark's runtime architecture, including the roles of the driver and executors, and explore deploying applications with various cluster managers like Standalone and Hadoop YARN. Additionally, you'll learn about configuring Spark applications, monitoring execution components, and key strategies for performance tuning. This day is crucial for mastering the deployment, tuning, and debugging of Spark applications, enhancing their efficiency and scalability in big data processing environments.
+Today's focus will be Spark's APIs, both from the new and old times.
+You will learn different data handling methods in Spark,
+and various optimization techniques that data engineers use to efficiently process data and draw conclusions from it.
 
 ## **Goals:**
 - Continue exploring advanced topics in Apache Spark to deepen your knowledge and skills in big data processing.
 - Build on the concepts and techniques covered in the previous days.
 
-## 7. Running on a Cluster
+## II. Structured APIs - DataFrames, SQL, and Datasets
+**Topics Covered:**
+- Structured API Overview
+- Basic Structured Operations
+- Working with Different Types of Data
+- Aggregations
+- Joins
+- Data Sources
+- Spark SQL
+- Datasets
 
-- **Topics Covered:**
-  - Introduction
-  - Spark Runtime Architecture
-  - The Driver
-  - Executors
-  - Cluster Manager Launching a Program Summary
-  - Deploying Applications with spark-submit
-  - Packaging Your Code and Dependencies
-  - Cluster Managers
-  - Standalone Cluster Manager
-  - Hadoop YARN
-  - Conclusion
+### Structured API Overview
+- DataFrames and Datasets
+- Schemas
+- Overview of Structured Spark Types
+- Overview of Structured API Execution
 
-#### Core Concepts
+### Basic Structured Operations
+- Schemas
+- Columns and Expressions
+- Records and Rows
+- DataFrame Transformations
 
-##### 1. **Spark Runtime Architecture:**
-   - Understand the architecture of a Spark cluster, including the roles of the Driver and Executors.
-   - Explore how data and tasks are distributed across nodes.
+### Working with Different Types of Data
+- Converting to Spark Types
+- Working with Booleans
+- Working with Numbers
+- Working with Strings
+- Working with Dates and Timestamps
+- Working with Nulls in Data
+- Ordering
+- Working with Complex Types
 
-##### 2. **Cluster Manager and Deployment:**
-   - Learn how Spark interacts with different cluster managers like Standalone and Hadoop YARN.
-   - Gain proficiency in deploying Spark applications using `spark-submit`.
+### Aggregations
+- Aggregation Functions
+- Grouping
+- Window Functions
+- Grouping Sets
+- User-Defined Aggregation Functions
 
-##### 3. **Packaging and Dependencies:**
-   - Pay attention to best practices for packaging your Spark application and managing dependencies.
-   - Understand the importance of self-contained JAR files.
+### Joins
+- Join Expressions
+- Join Types
+- Inner Joins
+- Left Outer Joins
+- Natural Joins
+- Challenges When Using Joins
+- How Spark Performs Joins
 
-### Chapter 8: Tuning and Debugging Spark
+### Data Sources
+- The Structure of the Data Sources API
+- CSV Files
+- JSON Files
+- Parquet Files
+- Advanced I/O Concepts
 
-- **Topics Covered:**
-  - Configuring Spark with SparkConf
-  - Components of Execution: Jobs, Tasks, and Stages
-  - Finding Information
-  - Spark Web UI
-  - Driver and Executor Logs
-  - Key Performance Considerations
-  - Level of Parallelism
-  - Serialization Format
-  - Memory Management
-  - Hardware Provisioning
-  - Conclusion
+### Spark SQL
+- Big Data and SQL: Apache Hive
+- Big Data and SQL: Spark SQL
+- How to Run Spark SQL Queries
+- Catalog
+- Tables
+- Views
+- Databases
+- Select Statements
+- Advanced Topics
+- Miscellaneous Features
 
-#### Core Concepts
+### Datasets
+- When to Use Datasets
+- Creating Datasets
 
-##### 1. **Spark Configuration and Tuning:**
-   - Explore the various configuration options available in Spark.
-   - Understand how to use `SparkConf` to fine-tune your Spark application.
+## III. Low-Level APIs
+**Topics Covered:**
+- Resilient Distributed Datasets (RDDs)
+- Advanced RDDs
+- Distributed Shared Variables
 
-##### 2. **Execution Components and Monitoring:**
-   - Learn about Spark's execution components, including Jobs, Tasks, and Stages.
-   - Utilize Spark's Web UI for monitoring and debugging.
+### Resilient Distributed Datasets (RDDs)
+- What Are the Low-Level APIs?
+- About RDDs
+- Creating RDDs
+- Manipulating RDDs
+- Transformations
+- Actions 
+- Saving Files
+- Caching
+- Checkpointing
+- Pipe RDDs to System Commands
 
-##### 3. **Performance Optimization:**
-   - Pay attention to key performance considerations, such as data locality, shuffling, and caching.
-   - Discover strategies for optimizing memory management and parallelism.
+### Advanced RDDs
+- Key-Value Basics (Key-Value RDDs)
+- Aggregations
+- Joins
+- Controlling Partitions
+- Custom Serialization
 
-### Wrapping Up the Day
-
-- **Discussion and Q&A (1 hour):**
-  - Engage in a discussion with mentors and peers to share experiences related to running Spark on a cluster.
-  - Ask questions and seek advice on tuning and optimizing Spark applications.
-
-**Great job on Day 12! You've explored advanced topics related to cluster management and performance optimization in Spark. Continue practicing and fine-tuning your Spark applications for maximum efficiency and scalability. Tomorrow, we'll dive into Spark SQL.**
+### Distributed Shared Variables
+- Broadcast Variables
+- Accumulators
 
 ## **Wrapping Up:** :hourglass_flowing_sand:
+**Great job on Day 16! You've explored advanced topics related to cluster management and performance optimization in Spark. Continue practicing and fine-tuning your Spark applications for maximum efficiency and scalability. Tomorrow, we'll dive into Spark SQL.**
+
 Discuss with your mentor about the day's learnings and explore potential project applications. Reflect on the significance of advanced Spark topics and how you can apply these concepts in your big data projects.
+
+**Discussion and Q&A (1 hour):** :raising_hand:
+  - Engage in a discussion with mentors and peers to share experiences related to running Spark on a cluster.
+  - Ask questions and seek advice on tuning and optimizing Spark applications.
 
 ## **Action Items:**
 - Identify areas for deeper exploration.  

--- a/chapter_04/day_17.md
+++ b/chapter_04/day_17.md
@@ -1,64 +1,53 @@
-# Day 17 - Exploring Spark SQL :bar_chart:
+# Day 17 - Spark Application Deployment :bar_chart:
 
 ## Overview:
-Today, you'll dive into the world of Spark SQL, a powerful module for working with structured data in Apache Spark. You'll explore the capabilities of Spark SQL, including querying structured data, integrating SQL with your Spark applications, and leveraging the power of DataFrames and Datasets for structured data processing.
+Thus far, we focused on Spark's properties as a programming interface.
+This chapter focuses on what happens when Spark goes about executing that code.
+Today, you'll learn how Spark applications are deployed to production as ran.
 
 ## **Goals:**
-- Dive into Spark SQL to harness the power of structured data processing in Apache Spark.
-- Learn how to leverage Spark SQL for querying structured data and integrating SQL with your Spark applications.
+- Dive into the architecture and components of the Spark application.
+- Understand low-level execution properties, such as pipelining.
 
-:warning: **Note:**
-- Spark SQL provides a powerful way to work with structured data, making it essential for data analysis and reporting in Spark applications.
-- Understanding Spark SQL will open up new possibilities for your big data projects.
+## IV. Production Applications
+**Topics Covered:**
+- How Spark Runs on a Cluster
+- Developing Spark Applications
+- Deploying Spark
+- Monitoring and Debugging
+- Performance Tuning
 
+### How Spark Runs on a Cluster
+- The Architecture of a Spark Application
+- The Life Cycle of a Spark Application (Outside Spark)
+- The Life Cycle of a Spark Application (Inside Spark)
+- Execution Details
 
-## 9. Spark SQL
+### Developing Spark Applications
+- Writing Spark Applications
+- Testing Spark Applications
+- The Development Process
+- Launching Applications
+- Configuring Applications
 
-- **Topics Covered:**
-  - Linking with Spark SQL
-  - Using Spark SQL in Applications
-  - Initializing Spark SQL
-  - Basic Query Example
-  - Caching
-  - User-Defined Functions
-  - Spark SQL UDFs
-  - Spark SQL Performance
-  - Performance Tuning Options
-  - Conclusion
+### Deploying Spark
+- Where to Deploy Your Cluster to Run Spark Applications
+- Cluster Managers
+- Miscellaneous Considerations
 
-#### Core Concepts
-
-##### 1. **Linking with Spark SQL:**
-   - Understand how to link Spark SQL with your Spark application.
-   - Explore the SparkSession API for creating a SQLContext.
-
-##### 2. **Using Spark SQL in Applications:**
-   - Learn how to incorporate Spark SQL into your Spark applications.
-   - Discover the benefits of using DataFrames and Datasets for structured data processing.
-
-##### 3. **Basic Query Example:**
-   - Walk through a basic Spark SQL query example.
-   - Understand the SQL syntax for querying structured data.
-
-##### 4. **Caching and Optimization:**
-   - Explore caching strategies in Spark SQL for improving query performance.
-   - Learn how to optimize queries using techniques like predicate pushdown.
-
-##### 5. **User-Defined Functions (UDFs):**
-   - Delve into the use of User-Defined Functions (UDFs) in Spark SQL.
-   - Create and apply UDFs to transform and manipulate data.
-
-##### 6. **Spark SQL Performance Tuning:**
-   - Pay attention to performance tuning options specific to Spark SQL.
-   - Optimize query execution and resource utilization.
-
-
-**Fantastic work on Day 13! You've explored Spark SQL and its capabilities for structured data processing. Continue practicing and applying Spark SQL in your projects to harness the power of structured data. Tomorrow, we'll disscuss and answer questions about what we've learned so far.**
+### Monitoring and Debugging
+- The Monitoring Landscape
+- What to Monitor
+- Spark Logs
+- The Spark UI
+- Debugging and Spark First Aid
 
 ## **Wrapping Up:** :hourglass_flowing_sand:
+**Fantastic work on Day 17! You've explored Spark SQL and its capabilities for structured data processing. Continue practicing and applying Spark SQL in your projects to harness the power of structured data. Tomorrow, we'll disscuss and answer questions about what we've learned so far.**
+
 Discuss with your mentor about the day's learnings and explore potential project applications. Reflect on the significance of Spark SQL and how you can apply these concepts in your big data projects.
 
-## **Q&A Session:** :raising_hand:
+**Q&A Session:** :raising_hand:
 - Engage in an open Q&A session with your mentor to address any queries or discussions about specific Spark SQL concepts, structured data processing, or the integration of SQL in Spark applications.
 - Seek recommendations for further exploration and resources to deepen your understanding of Spark SQL.
 


### PR DESCRIPTION
The spark oboarding focuses on an outdated Spark 1 book.
This means it does not contain any content regarding the highler level api that was introduced in Spark 2 (dataframes and datasets).